### PR TITLE
Fix/hide rtv planning buttons

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -22,7 +22,7 @@ export const Header = ({ label, subLabel, icon, onClick, isLoading, ...props }: 
         {icon}
       </CircleIcon>
       {isLoading ? (
-        <SkeletonText noOfLines={2} skeletonHeight="4rem" w="25rem" />
+        <SkeletonText noOfLines={2} skeletonHeight="2.5rem" w="25rem" />
       ) : (
         <Flex flexDir="column" align="flex-start">
           <Text textStyle={{ lg: 'h4', xl: 'h3' }} fontWeight={{ lg: 'normal' }}>

--- a/src/modules/customers/pages/CustomerDetailScreen/CustomerDetailScreen.tsx
+++ b/src/modules/customers/pages/CustomerDetailScreen/CustomerDetailScreen.tsx
@@ -9,8 +9,14 @@ import { CustomerPlanningTable, CustomerStatisticsSection } from './components';
 export const CustomerDetailScreen = () => {
   const { push, query } = useRouter();
   const customerId = Number(query.customer_id);
-  const { data: getCustomerData } = useGetFarmer({ farmerId: customerId });
-  const { data: getPlanningData, isLoading } = useGetPlanningStatistics(
+  const { data: getCustomerData, isLoading: isLoadingCustomer } = useGetFarmer({
+    farmerId: customerId,
+  });
+  const {
+    data: getPlanningData,
+    isLoading: isLoadingPlanning,
+    isFetching: isFetchingPlanning,
+  } = useGetPlanningStatistics(
     {
       userId: customerId,
     },
@@ -27,11 +33,11 @@ export const CustomerDetailScreen = () => {
         subLabel={Mask.formatCNPJ(customer?.company_identifier ?? '')}
         onClick={() => push('/clientes')}
         icon={<ChevronLeftIcon fontSize={36} color="white" />}
-        isLoading={isLoading}
+        isLoading={isLoadingCustomer}
       />
       <CustomerStatisticsSection
         summary={customerPlannings?.planning_summary}
-        isLoading={isLoading}
+        isLoading={isLoadingPlanning || isFetchingPlanning}
       />
       <CustomerPlanningTable />
     </>

--- a/src/modules/customers/pages/CustomerDetailScreen/CustomerDetailScreen.tsx
+++ b/src/modules/customers/pages/CustomerDetailScreen/CustomerDetailScreen.tsx
@@ -9,9 +9,12 @@ import { CustomerPlanningTable, CustomerStatisticsSection } from './components';
 export const CustomerDetailScreen = () => {
   const { push, query } = useRouter();
   const customerId = Number(query.customer_id);
-  const { data: getCustomerData, isLoading: isLoadingCustomer } = useGetFarmer({
-    farmerId: customerId,
-  });
+  const { data: getCustomerData, isLoading: isLoadingCustomer } = useGetFarmer(
+    {
+      farmerId: customerId,
+    },
+    { enabled: Boolean(customerId) },
+  );
   const {
     data: getPlanningData,
     isLoading: isLoadingPlanning,

--- a/src/modules/customers/pages/CustomerDetailScreen/components/CustomerPlanningTable/CustomerPlanningTable.tsx
+++ b/src/modules/customers/pages/CustomerDetailScreen/components/CustomerPlanningTable/CustomerPlanningTable.tsx
@@ -13,7 +13,10 @@ export const CustomerPlanningTable = () => {
   const { query, push } = useRouter();
   const customerId = Number(query.customer_id);
   const { currentPage, handleNextPage, handlePreviousPage } = usePagination();
-  const { data, isLoading } = useGetFarmerPlans({ page: currentPage, farmerId: customerId });
+  const { data, isLoading, isFetching } = useGetFarmerPlans({
+    page: currentPage,
+    farmerId: customerId,
+  });
   const plannings = data?.data ?? [];
   const pendingPlans = plannings.reduce((pendingValue, planning) => {
     if (planning.historic?.at(-1)?.status === 'ready_for_evaluation') {
@@ -31,7 +34,7 @@ export const CustomerPlanningTable = () => {
       <DynamicTable<Planning>
         variant="third"
         data={plannings}
-        isLoading={isLoading}
+        isLoading={isLoading || isFetching}
         columns={customerPlanningColumns}
         fallbackMessage="Nenhum planejamento encontrado"
         fallbackProps={{ fontSize: { base: '1.2rem', '3xl': '1.6rem' } }}

--- a/src/modules/customers/pages/CustomerPlanningDetailScreen/components/CustomerPlanningActionsTable/CustomerPlanningActions.columns.tsx
+++ b/src/modules/customers/pages/CustomerPlanningDetailScreen/components/CustomerPlanningActionsTable/CustomerPlanningActions.columns.tsx
@@ -10,25 +10,29 @@ import { CustomerPlanningTypeColumn } from './CustomerPlanningTypeColumn';
 const columnHelper = createColumnHelper<PlanningAction>();
 
 dayjs.extend(relativeTime);
-export const CustomerPlanningActionsColumns = [
-  columnHelper.accessor((data) => data.id, {
-    id: 'select',
-    header: ({ table }) => (
-      <Checkbox
-        isChecked={table.getIsAllRowsSelected()}
-        isIndeterminate={table.getIsSomeRowsSelected()}
-        onChange={table.getToggleAllRowsSelectedHandler()}
-      />
-    ),
-    cell: ({ row }) => (
-      <Checkbox
-        isChecked={row.getIsSelected()}
-        isDisabled={!row.getCanSelect()}
-        isIndeterminate={row.getIsSomeSelected()}
-        onChange={row.getToggleSelectedHandler()}
-      />
-    ),
-  }),
+export const CustomerPlanningActionsColumns = (planningStatus?: string) => [
+  ...(planningStatus
+    ? [
+        columnHelper.accessor((data) => data.id, {
+          id: 'select',
+          header: ({ table }) => (
+            <Checkbox
+              isChecked={table.getIsAllRowsSelected()}
+              isIndeterminate={table.getIsSomeRowsSelected()}
+              onChange={table.getToggleAllRowsSelectedHandler()}
+            />
+          ),
+          cell: ({ row }) => (
+            <Checkbox
+              isChecked={row.getIsSelected()}
+              isDisabled={!row.getCanSelect()}
+              isIndeterminate={row.getIsSomeSelected()}
+              onChange={row.getToggleSelectedHandler()}
+            />
+          ),
+        }),
+      ]
+    : []),
   columnHelper.accessor((data) => data.title, {
     id: 'tituloAcao',
     header: () => <Text>Título da ação</Text>,

--- a/src/modules/customers/pages/CustomerPlanningDetailScreen/components/CustomerPlanningActionsTable/CustomerPlanningActionsTable.tsx
+++ b/src/modules/customers/pages/CustomerPlanningDetailScreen/components/CustomerPlanningActionsTable/CustomerPlanningActionsTable.tsx
@@ -3,7 +3,11 @@ import dynamic from 'next/dynamic';
 import { useRouter } from 'next/router';
 import { useState } from 'react';
 
-import { useGetPlanningActions, useGetPlanningActionsStatistics } from '@/api';
+import {
+  useGetPlanningActions,
+  useGetPlanningActionsStatistics,
+  useGetPlanningStatus,
+} from '@/api';
 import { DynamicTable, Pagination } from '@/components';
 import { usePagination } from '@/hooks';
 
@@ -38,7 +42,9 @@ export const CustomerPlanningActionsTable = () => {
     { planningId, pagination: { page: currentPage, pageSize: 10 } },
     { enabled: Boolean(planningId) },
   );
-
+  const { data } = useGetPlanningStatus({ planningId }, { enabled: Boolean(planningId) });
+  const historic = data?.data.historic ?? [];
+  const planningStatus = historic[historic.length - 1].status;
   const metrics = metricsData?.data.metric;
   const actions = actionsData?.data ?? [];
   const farmKitValue = Number(metrics?.farm_kit_in_cents ?? 0);
@@ -110,6 +116,7 @@ export const CustomerPlanningActionsTable = () => {
       />
       <PlanningActionResume
         onApprove={onApprovePlanning}
+        planningStatus={planningStatus}
         onReject={onRejectPlanning}
         planningValue={planningValue}
       />

--- a/src/modules/customers/pages/CustomerPlanningDetailScreen/components/CustomerPlanningActionsTable/CustomerPlanningActionsTable.tsx
+++ b/src/modules/customers/pages/CustomerPlanningDetailScreen/components/CustomerPlanningActionsTable/CustomerPlanningActionsTable.tsx
@@ -32,19 +32,27 @@ export const CustomerPlanningActionsTable = () => {
   const [rowSelection, setRowSelection] = useState({});
   const [isApproving, setIsApproving] = useState(false);
   const planningId = Number(query.planning_id);
-  const { data: metricsData, isLoading: isLoadingMetrics } = useGetPlanningActionsStatistics(
+  const {
+    data: metricsData,
+    isLoading: isLoadingMetrics,
+    isFetching: isFetchingMetrics,
+  } = useGetPlanningActionsStatistics(
     {
       planningId,
     },
     { enabled: Boolean(planningId) },
   );
-  const { data: actionsData, isLoading: isLoadingActions } = useGetPlanningActions(
+  const {
+    data: actionsData,
+    isLoading: isLoadingActions,
+    isFetching: isFetchingActions,
+  } = useGetPlanningActions(
     { planningId, pagination: { page: currentPage, pageSize: 10 } },
     { enabled: Boolean(planningId) },
   );
   const { data } = useGetPlanningStatus({ planningId }, { enabled: Boolean(planningId) });
   const historic = data?.data.historic ?? [];
-  const planningStatus = historic[historic.length - 1].status;
+  const planningStatus = historic[historic.length - 1]?.status;
   const metrics = metricsData?.data.metric;
   const actions = actionsData?.data ?? [];
   const farmKitValue = Number(metrics?.farm_kit_in_cents ?? 0);
@@ -73,13 +81,13 @@ export const CustomerPlanningActionsTable = () => {
         farmKitValue={farmKitValue}
         farmTaskValue={farmTaskValue}
         relationshipTaskValue={relationshipTaskValue}
-        isLoading={isLoadingMetrics}
+        isLoading={isLoadingMetrics || isFetchingMetrics}
       />
       <DynamicTable<PlanningAction>
         variant="third"
         data={actions}
-        columns={CustomerPlanningActionsColumns}
-        isLoading={isLoadingActions}
+        columns={CustomerPlanningActionsColumns(planningStatus)}
+        isLoading={isLoadingActions || isFetchingActions}
         tableOptions={{
           enableRowSelection: (row) => row.original.status !== 'rejected',
           state: { rowSelection },

--- a/src/modules/customers/pages/CustomerPlanningDetailScreen/components/CustomerPlanningActionsTable/PlanningActionResume.tsx
+++ b/src/modules/customers/pages/CustomerPlanningDetailScreen/components/CustomerPlanningActionsTable/PlanningActionResume.tsx
@@ -6,9 +6,11 @@ type PlanningActionResumeProps = {
   planningValue: number;
   onApprove: () => void;
   onReject: () => void;
+  planningStatus?: string;
 };
 
 export const PlanningActionResume = ({
+  planningStatus,
   planningValue,
   onApprove,
   onReject,
@@ -28,14 +30,16 @@ export const PlanningActionResume = ({
           <Skeleton w="10rem" h="2rem" />
         )}
       </HStack>
-      <HStack>
-        <Button onClick={onReject} isDisabled={!hasPlanningValue} variant="fifth" size="sm">
-          Recusar planejamento
-        </Button>
-        <Button onClick={onApprove} isDisabled={!hasPlanningValue} size="sm">
-          <Text textStyle="footnote-small-bold">Autorizar planejamento</Text>
-        </Button>
-      </HStack>
+      {planningStatus && (
+        <HStack>
+          <Button onClick={onReject} isDisabled={!hasPlanningValue} variant="fifth" size="sm">
+            Recusar planejamento
+          </Button>
+          <Button onClick={onApprove} isDisabled={!hasPlanningValue} size="sm">
+            <Text textStyle="footnote-small-bold">Autorizar planejamento</Text>
+          </Button>
+        </HStack>
+      )}
     </Flex>
   );
 };

--- a/src/modules/customers/pages/CustomerPlanningDetailScreen/components/CustomerPlanningDetailCards/CustomerPlanningDetailCards.tsx
+++ b/src/modules/customers/pages/CustomerPlanningDetailScreen/components/CustomerPlanningDetailCards/CustomerPlanningDetailCards.tsx
@@ -8,7 +8,7 @@ import { Mask } from '@/utils';
 export const CustomerPlanningDetailCards = () => {
   const { query } = useRouter();
   const customerId = Number(query.customer_id);
-  const { data, isLoading } = useGetFarmer(
+  const { data, isLoading, isFetching } = useGetFarmer(
     { farmerId: customerId },
     { enabled: Boolean(customerId) },
   );
@@ -35,7 +35,7 @@ export const CustomerPlanningDetailCards = () => {
             <Text textStyle="footnote" color="text.footnote">
               Nome
             </Text>
-            {isLoading ? (
+            {isLoading || isFetching ? (
               <Skeleton noOfLines={1} h="3rem" w="23rem" />
             ) : (
               <Text textStyle="h4">{farmer?.users_permissions_user.username}</Text>
@@ -45,7 +45,7 @@ export const CustomerPlanningDetailCards = () => {
             <Text textStyle="footnote" color="text.footnote">
               CNPJ
             </Text>
-            {isLoading ? (
+            {isLoading || isFetching ? (
               <Skeleton noOfLines={1} h="3rem" w="23rem" />
             ) : (
               <Text textStyle="h4">{Mask.formatCNPJ(farmer?.company_identifier ?? '')}</Text>

--- a/src/modules/customers/pages/CustomersScreen/components/CustomerCards/CustomerCards.tsx
+++ b/src/modules/customers/pages/CustomersScreen/components/CustomerCards/CustomerCards.tsx
@@ -7,7 +7,7 @@ import { formatPrice } from '@/utils';
 export const CustomerCards = () => {
   const session = useSession();
   const userId = session.data?.user.id as number;
-  const { data, isLoading } = useGetManager(
+  const { data, isLoading, isFetching } = useGetManager(
     {
       id: userId,
     },
@@ -32,7 +32,7 @@ export const CustomerCards = () => {
       </Flex>
 
       <Flex layerStyle="card" align="center" p="2.4rem" gap="0.8rem" h="10rem">
-        {isLoading ? (
+        {isLoading || isFetching ? (
           <Skeleton w="15rem" h="4.8rem" />
         ) : (
           <Text textStyle="h2">{manager?.safra?.year}</Text>
@@ -43,7 +43,7 @@ export const CustomerCards = () => {
       </Flex>
 
       <Flex layerStyle="card" align="center" p="2.4rem" gap="0.8rem" h="10rem">
-        {isLoading ? (
+        {isLoading || isFetching ? (
           <Skeleton h="4.8rem" w="8rem" />
         ) : (
           <Text textStyle="h2">{manager?.farmers?.length}</Text>

--- a/src/modules/customers/pages/CustomersScreen/components/CustomerTable/CustomerTable.tsx
+++ b/src/modules/customers/pages/CustomersScreen/components/CustomerTable/CustomerTable.tsx
@@ -17,7 +17,7 @@ export const CustomerTable = () => {
   const userId = session.data?.user.id as number;
   const { currentPage, handleNextPage, handlePreviousPage } = usePagination('customer_table');
   const [search, setSearch] = useState('');
-  const { data, isLoading } = useGetCustomers(
+  const { data, isLoading, isFetching } = useGetCustomers(
     {
       id: userId,
       filter: { search },
@@ -52,7 +52,7 @@ export const CustomerTable = () => {
       <DynamicTable<Customer>
         data={customers}
         columns={CustomerColumns}
-        isLoading={isLoading}
+        isLoading={isLoading || isFetching}
         fallbackMessage="Nenhum cliente encontrado"
         fallbackProps={{ fontSize: { base: '1.2rem', '3xl': '1.6rem' } }}
         onRowClick={handleRowClick}


### PR DESCRIPTION
### Descrição

Esconde os botoes do RTV de autorizar e recusar planejamento caso planejamento esteja em construção

### O que eu fiz

- Esconde botoes com base no estado do planejamento
- Usa o isFetching nas tabelas do cliente 


### Como testar

Utilize as seguintes credenciais:
**Login:** produtor@bayer.com
**Senha:** Usuario123@

1. Acesse a plataforma e faça o login
2. Acesse a seguinte página: [/]()
3. Detalhe o passo a passo para testar as alterações.

<small>**Para alterações visuais ou regras de neǵocio específicas é recomendado a utilização de imagens, gifs ou vídeos.**</small>