### PR TITLE
Fix see planning button

### DIFF
--- a/src/modules/customers/pages/CustomerDetailScreen/components/CustomerPlanningTable/CustomerPendingPlanningNotification.tsx
+++ b/src/modules/customers/pages/CustomerDetailScreen/components/CustomerPlanningTable/CustomerPendingPlanningNotification.tsx
@@ -1,9 +1,11 @@
 import { Badge, Button, Center, Flex, HStack, Text } from '@chakra-ui/react';
 
 type CustomerPendingPlanningNotificationProps = {
+  onClick: () => void;
   quantity: number;
 };
 export const CustomerPendingPlanningNotification = ({
+  onClick,
   quantity,
 }: CustomerPendingPlanningNotificationProps) => {
   if (!quantity) return;
@@ -48,7 +50,7 @@ export const CustomerPendingPlanningNotification = ({
             </Text>
           </Center>
         </Badge>
-        <Button size="xs" px="1.6rem">
+        <Button onClick={onClick} size="xs" px="1.6rem">
           <Text textStyle="action3">Visualizar planejamento</Text>
         </Button>
       </HStack>

--- a/src/modules/customers/pages/CustomerDetailScreen/components/CustomerPlanningTable/CustomerPlanningTable.tsx
+++ b/src/modules/customers/pages/CustomerDetailScreen/components/CustomerPlanningTable/CustomerPlanningTable.tsx
@@ -8,6 +8,7 @@ import { usePagination } from '@/hooks';
 
 import { CustomerPendingPlanningNotification } from './CustomerPendingPlanningNotification';
 import { customerPlanningColumns } from './CustomerPlanningTable.columns';
+import { getPendingPlanningsSummary } from './utils';
 
 export const CustomerPlanningTable = () => {
   const { query, push } = useRouter();
@@ -18,19 +19,21 @@ export const CustomerPlanningTable = () => {
     farmerId: customerId,
   });
   const plannings = data?.data ?? [];
-  const pendingPlans = plannings.reduce((pendingValue, planning) => {
-    if (planning.historic?.at(-1)?.status === 'ready_for_evaluation') {
-      pendingValue++;
-    }
-    return pendingValue;
-  }, 0);
+
+  const pendingPlannings = getPendingPlanningsSummary(plannings);
 
   const onRowClick = (row: Row<Planning>) => push(`${customerId}/detalhes/${row.original.id}`);
+
+  const onClickPendingNotification = () =>
+    push(`${customerId}/detalhes/${pendingPlannings.mostRecentPendingPlanningId}`);
 
   return (
     <Flex flexDir="column" w="100%" gap="2.5rem" h="100%">
       <Text textStyle="h4">Planejamentos</Text>
-      <CustomerPendingPlanningNotification quantity={pendingPlans} />
+      <CustomerPendingPlanningNotification
+        onClick={onClickPendingNotification}
+        quantity={pendingPlannings.quantity}
+      />
       <DynamicTable<Planning>
         variant="third"
         data={plannings}

--- a/src/modules/customers/pages/CustomerDetailScreen/components/CustomerPlanningTable/utils/index.ts
+++ b/src/modules/customers/pages/CustomerDetailScreen/components/CustomerPlanningTable/utils/index.ts
@@ -1,0 +1,32 @@
+import dayjs from 'dayjs';
+
+const getMostRecentDate = (date1: string, date2: string) => {
+  const differenceFromTodayToDate1 = dayjs().diff((dayjs(date1), 'day'));
+  const differenteFromTodayToDate2 = dayjs().diff((dayjs(date2), 'day'));
+  const mostRecentDate = differenceFromTodayToDate1 < differenteFromTodayToDate2 ? date1 : date2;
+  return mostRecentDate;
+};
+
+export const getPendingPlanningsSummary = (plannings: Planning[]) => {
+  let currentMostRecentPlanningDate = '';
+
+  return plannings.reduce(
+    ({ quantity, mostRecentPendingPlanningId }, planning) => {
+      if (!currentMostRecentPlanningDate) currentMostRecentPlanningDate = planning.createdAt;
+
+      if (planning.historic?.at(-1)?.status === 'ready_for_evaluation') {
+        quantity++;
+      }
+
+      const mostRecentDate = getMostRecentDate(currentMostRecentPlanningDate, planning.createdAt);
+
+      mostRecentPendingPlanningId =
+        mostRecentDate === currentMostRecentPlanningDate
+          ? mostRecentPendingPlanningId
+          : planning.id;
+
+      return { quantity, mostRecentPendingPlanningId };
+    },
+    { quantity: 0, mostRecentPendingPlanningId: 0 },
+  );
+};

--- a/src/modules/customers/pages/CustomerDetailScreen/components/CustomerPlanningTable/utils/index.ts
+++ b/src/modules/customers/pages/CustomerDetailScreen/components/CustomerPlanningTable/utils/index.ts
@@ -12,18 +12,18 @@ export const getPendingPlanningsSummary = (plannings: Planning[]) => {
 
   return plannings.reduce(
     ({ quantity, mostRecentPendingPlanningId }, planning) => {
-      if (!currentMostRecentPlanningDate) currentMostRecentPlanningDate = planning.createdAt;
-
       if (planning.historic?.at(-1)?.status === 'ready_for_evaluation') {
+        if (!currentMostRecentPlanningDate) currentMostRecentPlanningDate = planning.updatedAt;
+
+        const mostRecentDate = getMostRecentDate(currentMostRecentPlanningDate, planning.updatedAt);
+
+        mostRecentPendingPlanningId =
+          mostRecentDate === currentMostRecentPlanningDate
+            ? mostRecentPendingPlanningId
+            : planning.id;
+
         quantity++;
       }
-
-      const mostRecentDate = getMostRecentDate(currentMostRecentPlanningDate, planning.createdAt);
-
-      mostRecentPendingPlanningId =
-        mostRecentDate === currentMostRecentPlanningDate
-          ? mostRecentPendingPlanningId
-          : planning.id;
 
       return { quantity, mostRecentPendingPlanningId };
     },

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -58,7 +58,7 @@ type Planning = {
   title: string;
   createdAt: string;
   id: number;
-  createdAt?: string;
+  updatedAt: string;
   safra?: Harvest;
   actions?: PlanningAction[];
   historic?: Historic[];


### PR DESCRIPTION
### Descrição

Corrige a ação de clicar no botão de visualizar planejamento pendente na tela de detalhes do cliente. Foi criado uma função para pegar um sumario referente aos planejamentos pendentes, onde o sumario tem o dado de quantos planejamentos estão pendentes, e qual é o planejamento que foi colocado como pronto para avaliação (pendente) primeiro
### O que eu fiz

- Alteração 1
- Alteração 2
- Alteração 3

### Como testar

Utilize as seguintes credenciais:
**Login:** produtor@bayer.com
**Senha:** Usuario123@

1. Acesse a plataforma e faça o login
2. Acesse a seguinte página: [/]()
3. Detalhe o passo a passo para testar as alterações.

<small>**Para alterações visuais ou regras de neǵocio específicas é recomendado a utilização de imagens, gifs ou vídeos.**</small>