### PR TITLE
Creates query to get pending plannings

### DIFF
--- a/src/api/planning/endpoints.ts
+++ b/src/api/planning/endpoints.ts
@@ -8,6 +8,8 @@ import {
   CreatePlanningResponse,
   DeletePlanningParams,
   DeletePlanningResponse,
+  GetFarmerPendingPlanningsParams,
+  GetFarmerPendingPlanningsResponse,
   GetFarmerPlansParams,
   GetFarmerPlansResponse,
   GetPlanningActionsParams,
@@ -76,6 +78,24 @@ export const getFarmerPlans = async ({
   });
 
   const { data } = await axios.authorized().get(`/plannings?${query}`);
+
+  return data;
+};
+
+export const getFarmerPendingPlannings = async ({
+  farmerId,
+}: GetFarmerPendingPlanningsParams): Promise<GetFarmerPendingPlanningsResponse> => {
+  const query = qs.stringify({
+    populate: {
+      plannings: {
+        populate: {
+          historic: true,
+        },
+      },
+    },
+  });
+
+  const { data } = await axios.authorized().get(`/farmers/${farmerId}?${query}`);
 
   return data;
 };

--- a/src/api/planning/queries/index.ts
+++ b/src/api/planning/queries/index.ts
@@ -4,3 +4,4 @@ export * from './useGetPlanningActionsStatistics';
 export * from './useGetPlanningActions';
 export * from './useGetPlanningHistoric';
 export * from './useGetPlanningStatus';
+export * from './useGetFarmerPendingPlannings';

--- a/src/api/planning/queries/useGetFarmerPendingPlannings.ts
+++ b/src/api/planning/queries/useGetFarmerPendingPlannings.ts
@@ -1,0 +1,16 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { QueryOpt } from '@/api';
+
+import { getFarmerPendingPlannings } from '../endpoints';
+import { GetFarmerPendingPlanningsParams, GetFarmerPendingPlanningsResponse } from '../types';
+
+export const useGetFarmerPendingPlannings = (
+  params: GetFarmerPendingPlanningsParams,
+  options?: QueryOpt<GetFarmerPendingPlanningsResponse>,
+) =>
+  useQuery({
+    ...options,
+    queryKey: ['farmer-pending-plannings', ...Object.values(params)],
+    queryFn: () => getFarmerPendingPlannings(params),
+  });

--- a/src/api/planning/types.ts
+++ b/src/api/planning/types.ts
@@ -92,3 +92,12 @@ export type DeletePlanningParams = {
   planningId: number;
 };
 export type DeletePlanningResponse = void;
+
+export type GetFarmerPendingPlanningsParams = {
+  farmerId: number;
+};
+export type GetFarmerPendingPlanningsResponse = {
+  data: {
+    plannings: Planning[];
+  };
+};

--- a/src/components/Balance/BalanceContainer.tsx
+++ b/src/components/Balance/BalanceContainer.tsx
@@ -26,7 +26,6 @@ export const BalanceContainer = ({ farmerId, children, ...restProps }: BalancePr
   const expirationDateValue = formatDate(
     dataGetFarmer?.data?.[0]?.safra?.deadline_to_add_plannings,
   );
-
   return (
     <BalanceContext.Provider
       value={{

--- a/src/modules/customers/pages/CustomerDetailScreen/components/CustomerPlanningTable/CustomerPendingPlanningNotification.tsx
+++ b/src/modules/customers/pages/CustomerDetailScreen/components/CustomerPlanningTable/CustomerPendingPlanningNotification.tsx
@@ -1,14 +1,23 @@
 import { Badge, Button, Center, Flex, HStack, Text } from '@chakra-ui/react';
+import { useRouter } from 'next/router';
 
-type CustomerPendingPlanningNotificationProps = {
-  onClick: () => void;
-  quantity: number;
-};
-export const CustomerPendingPlanningNotification = ({
-  onClick,
-  quantity,
-}: CustomerPendingPlanningNotificationProps) => {
-  if (!quantity) return;
+import { useGetFarmerPendingPlannings } from '@/api';
+
+import { getPendingPlanningsSummary } from './utils';
+
+export const CustomerPendingPlanningNotification = () => {
+  const { query, push } = useRouter();
+  const customerId = Number(query.customer_id);
+  const { data } = useGetFarmerPendingPlannings(
+    { farmerId: customerId },
+    { enabled: Boolean(customerId) },
+  );
+  const plannings = data?.data.plannings ?? [];
+  const pendingPlannings = getPendingPlanningsSummary(plannings);
+  if (!pendingPlannings.quantity) return;
+
+  const onClickPendingNotification = () =>
+    push(`${customerId}/detalhes/${pendingPlannings.mostRecentPendingPlanningId}`);
   return (
     <Flex
       align="center"
@@ -46,11 +55,11 @@ export const CustomerPendingPlanningNotification = ({
             borderColor="opacity.yellow.0.30"
           >
             <Text textStyle="footnote" color="surface.primary" lineHeight="0">
-              {quantity}
+              {pendingPlannings.quantity}
             </Text>
           </Center>
         </Badge>
-        <Button onClick={onClick} size="xs" px="1.6rem">
+        <Button onClick={onClickPendingNotification} size="xs" px="1.6rem">
           <Text textStyle="action3">Visualizar planejamento</Text>
         </Button>
       </HStack>

--- a/src/modules/customers/pages/CustomerDetailScreen/components/CustomerPlanningTable/CustomerPlanningTable.tsx
+++ b/src/modules/customers/pages/CustomerDetailScreen/components/CustomerPlanningTable/CustomerPlanningTable.tsx
@@ -8,7 +8,6 @@ import { usePagination } from '@/hooks';
 
 import { CustomerPendingPlanningNotification } from './CustomerPendingPlanningNotification';
 import { customerPlanningColumns } from './CustomerPlanningTable.columns';
-import { getPendingPlanningsSummary } from './utils';
 
 export const CustomerPlanningTable = () => {
   const { query, push } = useRouter();
@@ -19,21 +18,12 @@ export const CustomerPlanningTable = () => {
     farmerId: customerId,
   });
   const plannings = data?.data ?? [];
-
-  const pendingPlannings = getPendingPlanningsSummary(plannings);
-
   const onRowClick = (row: Row<Planning>) => push(`${customerId}/detalhes/${row.original.id}`);
-
-  const onClickPendingNotification = () =>
-    push(`${customerId}/detalhes/${pendingPlannings.mostRecentPendingPlanningId}`);
 
   return (
     <Flex flexDir="column" w="100%" gap="2.5rem" h="100%">
       <Text textStyle="h4">Planejamentos</Text>
-      <CustomerPendingPlanningNotification
-        onClick={onClickPendingNotification}
-        quantity={pendingPlannings.quantity}
-      />
+      <CustomerPendingPlanningNotification />
       <DynamicTable<Planning>
         variant="third"
         data={plannings}


### PR DESCRIPTION
### Descrição

Corrige o display de quantos planejamentos pendentes existem para aquele usuario


### O que eu fiz

- Alteração 1
- Alteração 2
- Alteração 3

### Como testar

Utilize as seguintes credenciais:
**Login:** produtor@bayer.com
**Senha:** Usuario123@

1. Acesse a plataforma e faça o login
2. Acesse a seguinte página: [/]()
3. Detalhe o passo a passo para testar as alterações.

<small>**Para alterações visuais ou regras de neǵocio específicas é recomendado a utilização de imagens, gifs ou vídeos.**</small>