### PR TITLE
Creates util to invalidate queries, invalidaes queries on mutation

### DIFF
--- a/src/api/planning/mutations/useUpdatePlanningHistoric.ts
+++ b/src/api/planning/mutations/useUpdatePlanningHistoric.ts
@@ -1,6 +1,7 @@
 import { useMutation } from '@tanstack/react-query';
 
 import { MutOpt, UpdatePlanningHistoricResponse } from '@/api';
+import { invalidateQueries } from '@/utils';
 
 import { updatePlanningHistoric } from '../endpoints';
 
@@ -9,4 +10,14 @@ export const useUpdatePlanningHistoric = (options?: MutOpt<UpdatePlanningHistori
     ...options,
     mutationKey: ['update-historic'],
     mutationFn: updatePlanningHistoric,
+    onSuccess: () => {
+      invalidateQueries([
+        'get-customers',
+        'farmer-plans',
+        'planning-historic',
+        'planning-status',
+        'planning-actions-statistics',
+        'planning-actions',
+      ]);
+    },
   });

--- a/src/api/planning/mutations/useUpdatePlanningHistoric.ts
+++ b/src/api/planning/mutations/useUpdatePlanningHistoric.ts
@@ -11,13 +11,13 @@ export const useUpdatePlanningHistoric = (options?: MutOpt<UpdatePlanningHistori
     mutationKey: ['update-historic'],
     mutationFn: updatePlanningHistoric,
     onSuccess: () => {
-      invalidateQueries([
+      invalidateQueries(
         'get-customers',
         'farmer-plans',
         'planning-historic',
         'planning-status',
         'planning-actions-statistics',
         'planning-actions',
-      ]);
+      );
     },
   });

--- a/src/api/planning/mutations/useUpdatePlanningHistoric.ts
+++ b/src/api/planning/mutations/useUpdatePlanningHistoric.ts
@@ -12,6 +12,7 @@ export const useUpdatePlanningHistoric = (options?: MutOpt<UpdatePlanningHistori
     mutationFn: updatePlanningHistoric,
     onSuccess: () => {
       invalidateQueries(
+        'farmer-pending-plannings',
         'get-customers',
         'farmer-plans',
         'planning-historic',

--- a/src/modules/planning/pages/CreatePlanningScreen/components/PlanningHistoricDrawer/SendPlanningFormStep.tsx
+++ b/src/modules/planning/pages/CreatePlanningScreen/components/PlanningHistoricDrawer/SendPlanningFormStep.tsx
@@ -9,7 +9,6 @@ import {
 } from '@/api';
 import { Historic, HistoricDrawer, Pagination } from '@/components';
 import { usePagination } from '@/hooks';
-import { queryClient } from '@/lib/react-query';
 
 import { SendPlanningFormStepSchemaType } from './SendPlanningFormStep.schema';
 
@@ -75,11 +74,6 @@ export const SendPlanningFormStep = ({
       },
       {
         onSuccess: () => {
-          queryClient.invalidateQueries(['planning-historic']);
-          queryClient.invalidateQueries(['planning-status']);
-          queryClient.invalidateQueries(['planning-actions-statistics']);
-          queryClient.invalidateQueries(['planning-actions']);
-
           handleCloseSendPlanningDrawer(resetPage);
           toast({
             description: 'O planejamento foi enviado para aprovação.',

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -14,3 +14,4 @@ export * from './formatMonth';
 export * from './brlToNumber';
 export * from './brlToCents';
 export * from './formatValue';
+export * from './invalidateQueries';

--- a/src/utils/invalidateQueries.ts
+++ b/src/utils/invalidateQueries.ts
@@ -1,0 +1,4 @@
+import { queryClient } from '@/lib/react-query';
+
+export const invalidateQueries = (queries: string[]) =>
+  queries.forEach((querie) => queryClient.invalidateQueries([querie]));

--- a/src/utils/invalidateQueries.ts
+++ b/src/utils/invalidateQueries.ts
@@ -1,4 +1,4 @@
 import { queryClient } from '@/lib/react-query';
 
-export const invalidateQueries = (queries: string[]) =>
+export const invalidateQueries = (...queries: string[]) =>
   queries.forEach((querie) => queryClient.invalidateQueries([querie]));


### PR DESCRIPTION
### Descrição

Invalida as queries diretamente na mutation do updatePlanningsHistoric e cria um utils para fazer isso

### O que eu fiz

- Alteração 1
- Alteração 2
- Alteração 3

### Como testar

Utilize as seguintes credenciais:
**Login:** produtor@bayer.com
**Senha:** Usuario123@

1. Acesse a plataforma e faça o login
2. Acesse a seguinte página: [/]()
3. Detalhe o passo a passo para testar as alterações.

<small>**Para alterações visuais ou regras de neǵocio específicas é recomendado a utilização de imagens, gifs ou vídeos.**</small>